### PR TITLE
feat(6): sort the categories by the display_order field

### DIFF
--- a/src/views/CategoriesView/CategoriesView.js
+++ b/src/views/CategoriesView/CategoriesView.js
@@ -47,9 +47,10 @@ function CategoriesView() {
 				categoriesHook.clearCategories();
 			}
 
+			// Sort categories by display_order before setting state
 			setCategoriesData((prevState) => ({
 				...prevState,
-				list: response.data
+				list: [...response.data].sort((a, b) => a.display_order - b.display_order)
 			}));
 		} catch (err) {
 			setCategoriesData((prevState) => {


### PR DESCRIPTION
- Added a sort operation to the categories array before setting it in the state
- Used the spread operator (...) to create a new array before sorting to avoid mutating the original response data
- Sorted the categories in ascending order based on the display_order field